### PR TITLE
Remove upnp2 service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Ubiquity USG with KPN FTTH, IPTV and IPv6
+# Ubiquiti USG with KPN FTTH, IPTV and IPv6
 This repo contains the files you need to succesfully configure the USG with KPN FTTH with IPTV and IPv6 enabled.
 
 1. Place **config.gateway.json** at the unifi controller (*sites/default*) via SCP
@@ -30,6 +30,42 @@ The PPPOE interface has no "public" IPv6 address because it uses the link local 
 show interfaces pppoe pppoe2 log | match "IPV6|LL"
 ```
 
+## VLANs
+
+If you are using VLANs and have issues with the IPTV having hickups or being frozen you can try to change the config as follows:
+
+At the "igmp-proxy" section replace "eth1" with "eth.{vlan}" where {vlan} would be the VLAN where your decoders are in. 
+
+```
+"eth1.100": {
+    "alt-subnet": [
+        "0.0.0.0/0"
+    ],
+    "role": "downstream",
+    "threshold": "1"
+}
+```
+
+To prevent the IPTV from flooding other network interfaces it's best to explicitly disable the proxy for these interfaces:
+
+```
+"eth1": {
+    "role": "disabled",
+    "threshold": "1"
+},
+"eth1.200": {
+    "role": "disabled",
+    "threshold": "1"
+},
+"eth1.300": {
+    "role": "disabled",
+    "threshold": "1"
+}
+```
+
+An example config of the igmp configuration can be found in the file igmp-proxy.example.json.
+
+
 XS4ALL (a Dutch ISP which uses the KPN platform has more information regarding the technical details), more info can be found [here](https://www.xs4all.nl/service/diensten/internet/installeren/modem-instellen/hoe-kan-ik-een-ander-modem-dan-fritzbox-instellen.htm)
 
 This config.gateway.json has been tested on the following versions:
@@ -39,7 +75,7 @@ UniFi Security Gateway 3P: 4.4.44.5213844
 Unifi Controller: 5.11.46 (Build: atag_5.11.46_12723)
 ```
 
-My unifi WAN settings in the controller are as follows:
+My Unifi WAN settings in the controller are as follows:
 
 ![unifiwan](https://raw.githubusercontent.com/coolhva/usg-kpn-ftth/master/unifi_wan.png)
 

--- a/config.gateway.json
+++ b/config.gateway.json
@@ -1,237 +1,231 @@
 {
-    "system": {
-        "task-scheduler": {
-            "task": {
-                "postprovision": {
-                	"executable": {
-                        "path": "/config/scripts/post-config.d/dhcp6.sh"
-                    },
-                    "interval": "2m"
-                },
-                "postprovisionroutes": {
-                	"executable": {
-                        "path": "/config/scripts/post-config.d/setroutes.sh"
-                    },
-                    "interval": "2m"
-                }
-            }
-        }
-    },
-    "firewall": {
-        "ipv6-name": {
-            "WANv6_LOCAL" : {
-                "rule": {
-                    "1": {
-                        "action": "accept",
-                        "description": "Allow ICMPv6",
-                        "log": "enable",
-                        "protocol": "icmpv6"
-                    },
-                    "2": {
-                        "action": "accept",
-                        "description": "DHCPv6",
-                        "destination": {
-                                "port": "546"
-                        },
-                        "protocol": "udp",
-                        "source": {
-                                "port": "547"
-                        }
-                    }
-                }
-            },
-            "WANv6_IN" : {
-                "rule": {
-                    "1": {
-                            "action": "accept",
-                            "description": "Allow ICMPv6",
-                            "log": "enable",
-                            "protocol": "icmpv6"
-                    }
-                }
-            }
-        }
-    },
-    "interfaces": {
-        "ethernet": {
-            "eth0": {
-                "dhcp-options": {
-                    "default-route": "no-update",
-                    "default-route-distance": "1",
-                    "name-server": "no-update"
-                },
-                "description": "WAN",
-                "mtu": "1512",
-                "vif": {
-                    "4": {
-                        "address": [
-                            "dhcp"
-                        ],
-                        "description": "IPTV",
-                        "dhcp-options": {
-                            "client-option": [
-                                "send vendor-class-identifier &quot;IPTV_RG&quot;;",
-                                "request subnet-mask, routers, rfc3442-classless-static-routes;"
-                            ],
-                            "default-route": "no-update",
-                            "default-route-distance": "210",
-                            "name-server": "no-update"
-                        },
-                        "ip": {
-                            "source-validation": "loose"
-                        },
-                        "mtu": "1500"
-                    },
-                    "6": {
-                        "mtu": "1508",
-                        "firewall": {
-                            "in": {
-                                "ipv6-name": "WANv6_IN",
-                                "name": "WAN_IN"
-                            },
-                            "local": {
-                                "ipv6-name": "WANv6_LOCAL",
-                                "name": "WAN_LOCAL"
-                            },
-                            "out": {
-                                "ipv6-name": "WANv6_OUT",
-                                "name": "WAN_OUT"
-                            }
-                        },
-                        "pppoe": {
-                            "2": {
-                                "default-route": "auto",
-                                "firewall": {
-                                    "in": {
-                                        "ipv6-name": "WANv6_IN",
-                                        "name": "WAN_IN"
-                                    },
-                                    "local": {
-                                        "ipv6-name": "WANv6_LOCAL",
-                                        "name": "WAN_LOCAL"
-                                    },
-                                    "out": {
-                                        "ipv6-name": "WANv6_OUT",
-                                        "name": "WAN_OUT"
-                                    }
-                                },
-                                "ipv6": {
-                                    "address": {
-                                        "autoconf": "''"
-                                    },
-                                    "dup-addr-detect-transmits": "1",
-                                    "enable": "''"
-                                },
-                                "mtu": "1500",
-                                "name-server": "auto",
-                                "password": "kpn",
-                                "user-id": "kpn"
-                            }
-                        }
-                    }
-                }
-            },
-            "eth1": {
-                "description": "LAN",
-                "ipv6": {
-                    "address": {
-                        "autoconf": "''"
-                    },
-                    "dup-addr-detect-transmits": "1",
-                    "router-advert": {
-                        "cur-hop-limit": "64",
-                        "link-mtu": "0",
-                        "managed-flag": "true",
-                        "max-interval": "600",
-                        "name-server": [
-                        	"2606:4700:4700::1111",
-                        	"2606:4700:4700::1001"
-                        ],
-                        "other-config-flag": "false",
-                        "prefix": {
-                            "::/64": {
-                                "autonomous-flag": "true",
-                                "on-link-flag": "true",
-                                "valid-lifetime": "2592000"
-                            }
-                        },
-
-                        "radvd-options": "RDNSS 2606:4700:4700::1111 2606:4700:4700::1001 {};",
-                        "reachable-time": "0",
-                        "retrans-timer": "0",
-                        "send-advert": "true"
-                    }
-                }
-            }
-        }
-    },
-    "protocols": {
-        "igmp-proxy": {
-            "interface": {
-                "eth0.4": {
-                    "alt-subnet": [
-                        "0.0.0.0/0"
-                    ],
-                    "role": "upstream",
-                    "threshold": "1"
-                },
-                "eth1": {
-                    "alt-subnet": [
-                        "0.0.0.0/0"
-                    ],
-                    "role": "downstream",
-                    "threshold": "1"
-                }
-            }
-        },
-        "static": {
-            "interface-route6": {
-                "::/0": {
-                    "next-hop-interface": {
-                        "pppoe2": "''"
-                    }
-                }
-            }
-        }
-    },
-    "port-forward": {
-        "wan-interface": "pppoe2"
-    },
-
-    "service": {
-        "dns": {
-            "forwarding": {
-                "except-interface": [
-                    "pppoe2"
-                ]
-            }
-        },
-        "nat": {
-            "rule": {
-                "5000": {
-                    "description": "MASQ corporate_network to IPTV network",
-                    "destination": {
-                        "address": "213.75.112.0/21"
-                    },
-                    "log": "disable",
-                    "outbound-interface": "eth0.4",
-                    "protocol": "all",
-                    "type": "masquerade"
-                },
-                "6001": {
-                    "outbound-interface": "pppoe2"
-                },
-                "6002": {
-                    "outbound-interface": "pppoe2"
-                },
-                "6003": {
-                    "outbound-interface": "pppoe2"
-                }
-            }
-        },
-        "upnp2": {
-            "wan": "pppoe2"
-        }
-
-    }
+	"system": {
+		"task-scheduler": {
+			"task": {
+				"postprovision": {
+					"executable": {
+						"path": "/config/scripts/post-config.d/dhcp6.sh"
+					},
+					"interval": "2m"
+				},
+				"postprovisionroutes": {
+					"executable": {
+						"path": "/config/scripts/post-config.d/setroutes.sh"
+					},
+					"interval": "2m"
+				}
+			}
+		}
+	},
+	"firewall": {
+		"ipv6-name": {
+			"WANv6_LOCAL": {
+				"rule": {
+					"1": {
+						"action": "accept",
+						"description": "Allow ICMPv6",
+						"log": "enable",
+						"protocol": "icmpv6"
+					},
+					"2": {
+						"action": "accept",
+						"description": "DHCPv6",
+						"destination": {
+							"port": "546"
+						},
+						"protocol": "udp",
+						"source": {
+							"port": "547"
+						}
+					}
+				}
+			},
+			"WANv6_IN": {
+				"rule": {
+					"1": {
+						"action": "accept",
+						"description": "Allow ICMPv6",
+						"log": "enable",
+						"protocol": "icmpv6"
+					}
+				}
+			}
+		}
+	},
+	"interfaces": {
+		"ethernet": {
+			"eth0": {
+				"dhcp-options": {
+					"default-route": "no-update",
+					"default-route-distance": "1",
+					"name-server": "no-update"
+				},
+				"description": "WAN",
+				"mtu": "1512",
+				"vif": {
+					"4": {
+						"address": [
+							"dhcp"
+						],
+						"description": "IPTV",
+						"dhcp-options": {
+							"client-option": [
+								"send vendor-class-identifier &quot;IPTV_RG&quot;;",
+								"request subnet-mask, routers, rfc3442-classless-static-routes;"
+							],
+							"default-route": "no-update",
+							"default-route-distance": "210",
+							"name-server": "no-update"
+						},
+						"ip": {
+							"source-validation": "loose"
+						},
+						"mtu": "1500"
+					},
+					"6": {
+						"mtu": "1508",
+						"firewall": {
+							"in": {
+								"ipv6-name": "WANv6_IN",
+								"name": "WAN_IN"
+							},
+							"local": {
+								"ipv6-name": "WANv6_LOCAL",
+								"name": "WAN_LOCAL"
+							},
+							"out": {
+								"ipv6-name": "WANv6_OUT",
+								"name": "WAN_OUT"
+							}
+						},
+						"pppoe": {
+							"2": {
+								"default-route": "auto",
+								"firewall": {
+									"in": {
+										"ipv6-name": "WANv6_IN",
+										"name": "WAN_IN"
+									},
+									"local": {
+										"ipv6-name": "WANv6_LOCAL",
+										"name": "WAN_LOCAL"
+									},
+									"out": {
+										"ipv6-name": "WANv6_OUT",
+										"name": "WAN_OUT"
+									}
+								},
+								"ipv6": {
+									"address": {
+										"autoconf": "''"
+									},
+									"dup-addr-detect-transmits": "1",
+									"enable": "''"
+								},
+								"mtu": "1500",
+								"name-server": "auto",
+								"password": "kpn",
+								"user-id": "kpn"
+							}
+						}
+					}
+				}
+			},
+			"eth1": {
+				"description": "LAN",
+				"ipv6": {
+					"address": {
+						"autoconf": "''"
+					},
+					"dup-addr-detect-transmits": "1",
+					"router-advert": {
+						"cur-hop-limit": "64",
+						"link-mtu": "0",
+						"managed-flag": "true",
+						"max-interval": "600",
+						"name-server": [
+							"2606:4700:4700::1111",
+							"2606:4700:4700::1001"
+						],
+						"other-config-flag": "false",
+						"prefix": {
+							"::/64": {
+								"autonomous-flag": "true",
+								"on-link-flag": "true",
+								"valid-lifetime": "2592000"
+							}
+						},
+						"radvd-options": "RDNSS 2606:4700:4700::1111 2606:4700:4700::1001 {};",
+						"reachable-time": "0",
+						"retrans-timer": "0",
+						"send-advert": "true"
+					}
+				}
+			}
+		}
+	},
+	"protocols": {
+		"igmp-proxy": {
+			"interface": {
+				"eth0.4": {
+					"alt-subnet": [
+						"0.0.0.0/0"
+					],
+					"role": "upstream",
+					"threshold": "1"
+				},
+				"eth1": {
+					"alt-subnet": [
+						"0.0.0.0/0"
+					],
+					"role": "downstream",
+					"threshold": "1"
+				}
+			}
+		},
+		"static": {
+			"interface-route6": {
+				"::/0": {
+					"next-hop-interface": {
+						"pppoe2": "''"
+					}
+				}
+			}
+		}
+	},
+	"port-forward": {
+		"wan-interface": "pppoe2"
+	},
+	"service": {
+		"dns": {
+			"forwarding": {
+				"except-interface": [
+					"pppoe2"
+				]
+			}
+		},
+		"nat": {
+			"rule": {
+				"5000": {
+					"description": "MASQ corporate_network to IPTV network",
+					"destination": {
+						"address": "213.75.112.0/21"
+					},
+					"log": "disable",
+					"outbound-interface": "eth0.4",
+					"protocol": "all",
+					"type": "masquerade"
+				},
+				"6001": {
+					"outbound-interface": "pppoe2"
+				},
+				"6002": {
+					"outbound-interface": "pppoe2"
+				},
+				"6003": {
+					"outbound-interface": "pppoe2"
+				}
+			}
+		}
+	}
 }

--- a/config.gateway.json
+++ b/config.gateway.json
@@ -1,231 +1,231 @@
 {
-	"system": {
-		"task-scheduler": {
-			"task": {
-				"postprovision": {
-					"executable": {
-						"path": "/config/scripts/post-config.d/dhcp6.sh"
-					},
-					"interval": "2m"
-				},
-				"postprovisionroutes": {
-					"executable": {
-						"path": "/config/scripts/post-config.d/setroutes.sh"
-					},
-					"interval": "2m"
-				}
-			}
-		}
-	},
-	"firewall": {
-		"ipv6-name": {
-			"WANv6_LOCAL": {
-				"rule": {
-					"1": {
-						"action": "accept",
-						"description": "Allow ICMPv6",
-						"log": "enable",
-						"protocol": "icmpv6"
-					},
-					"2": {
-						"action": "accept",
-						"description": "DHCPv6",
-						"destination": {
-							"port": "546"
-						},
-						"protocol": "udp",
-						"source": {
-							"port": "547"
-						}
-					}
-				}
-			},
-			"WANv6_IN": {
-				"rule": {
-					"1": {
-						"action": "accept",
-						"description": "Allow ICMPv6",
-						"log": "enable",
-						"protocol": "icmpv6"
-					}
-				}
-			}
-		}
-	},
-	"interfaces": {
-		"ethernet": {
-			"eth0": {
-				"dhcp-options": {
-					"default-route": "no-update",
-					"default-route-distance": "1",
-					"name-server": "no-update"
-				},
-				"description": "WAN",
-				"mtu": "1512",
-				"vif": {
-					"4": {
-						"address": [
-							"dhcp"
-						],
-						"description": "IPTV",
-						"dhcp-options": {
-							"client-option": [
-								"send vendor-class-identifier &quot;IPTV_RG&quot;;",
-								"request subnet-mask, routers, rfc3442-classless-static-routes;"
-							],
-							"default-route": "no-update",
-							"default-route-distance": "210",
-							"name-server": "no-update"
-						},
-						"ip": {
-							"source-validation": "loose"
-						},
-						"mtu": "1500"
-					},
-					"6": {
-						"mtu": "1508",
-						"firewall": {
-							"in": {
-								"ipv6-name": "WANv6_IN",
-								"name": "WAN_IN"
-							},
-							"local": {
-								"ipv6-name": "WANv6_LOCAL",
-								"name": "WAN_LOCAL"
-							},
-							"out": {
-								"ipv6-name": "WANv6_OUT",
-								"name": "WAN_OUT"
-							}
-						},
-						"pppoe": {
-							"2": {
-								"default-route": "auto",
-								"firewall": {
-									"in": {
-										"ipv6-name": "WANv6_IN",
-										"name": "WAN_IN"
-									},
-									"local": {
-										"ipv6-name": "WANv6_LOCAL",
-										"name": "WAN_LOCAL"
-									},
-									"out": {
-										"ipv6-name": "WANv6_OUT",
-										"name": "WAN_OUT"
-									}
-								},
-								"ipv6": {
-									"address": {
-										"autoconf": "''"
-									},
-									"dup-addr-detect-transmits": "1",
-									"enable": "''"
-								},
-								"mtu": "1500",
-								"name-server": "auto",
-								"password": "kpn",
-								"user-id": "kpn"
-							}
-						}
-					}
-				}
-			},
-			"eth1": {
-				"description": "LAN",
-				"ipv6": {
-					"address": {
-						"autoconf": "''"
-					},
-					"dup-addr-detect-transmits": "1",
-					"router-advert": {
-						"cur-hop-limit": "64",
-						"link-mtu": "0",
-						"managed-flag": "true",
-						"max-interval": "600",
-						"name-server": [
-							"2606:4700:4700::1111",
-							"2606:4700:4700::1001"
-						],
-						"other-config-flag": "false",
-						"prefix": {
-							"::/64": {
-								"autonomous-flag": "true",
-								"on-link-flag": "true",
-								"valid-lifetime": "2592000"
-							}
-						},
-						"radvd-options": "RDNSS 2606:4700:4700::1111 2606:4700:4700::1001 {};",
-						"reachable-time": "0",
-						"retrans-timer": "0",
-						"send-advert": "true"
-					}
-				}
-			}
-		}
-	},
-	"protocols": {
-		"igmp-proxy": {
-			"interface": {
-				"eth0.4": {
-					"alt-subnet": [
-						"0.0.0.0/0"
-					],
-					"role": "upstream",
-					"threshold": "1"
-				},
-				"eth1": {
-					"alt-subnet": [
-						"0.0.0.0/0"
-					],
-					"role": "downstream",
-					"threshold": "1"
-				}
-			}
-		},
-		"static": {
-			"interface-route6": {
-				"::/0": {
-					"next-hop-interface": {
-						"pppoe2": "''"
-					}
-				}
-			}
-		}
-	},
-	"port-forward": {
-		"wan-interface": "pppoe2"
-	},
-	"service": {
-		"dns": {
-			"forwarding": {
-				"except-interface": [
-					"pppoe2"
-				]
-			}
-		},
-		"nat": {
-			"rule": {
-				"5000": {
-					"description": "MASQ corporate_network to IPTV network",
-					"destination": {
-						"address": "213.75.112.0/21"
-					},
-					"log": "disable",
-					"outbound-interface": "eth0.4",
-					"protocol": "all",
-					"type": "masquerade"
-				},
-				"6001": {
-					"outbound-interface": "pppoe2"
-				},
-				"6002": {
-					"outbound-interface": "pppoe2"
-				},
-				"6003": {
-					"outbound-interface": "pppoe2"
-				}
-			}
-		}
-	}
+    "system": {
+        "task-scheduler": {
+            "task": {
+                "postprovision": {
+                	"executable": {
+                        "path": "/config/scripts/post-config.d/dhcp6.sh"
+                    },
+                    "interval": "2m"
+                },
+                "postprovisionroutes": {
+                	"executable": {
+                        "path": "/config/scripts/post-config.d/setroutes.sh"
+                    },
+                    "interval": "2m"
+                }
+            }
+        }
+    },
+    "firewall": {
+        "ipv6-name": {
+            "WANv6_LOCAL" : {
+                "rule": {
+                    "1": {
+                        "action": "accept",
+                        "description": "Allow ICMPv6",
+                        "log": "enable",
+                        "protocol": "icmpv6"
+                    },
+                    "2": {
+                        "action": "accept",
+                        "description": "DHCPv6",
+                        "destination": {
+                                "port": "546"
+                        },
+                        "protocol": "udp",
+                        "source": {
+                                "port": "547"
+                        }
+                    }
+                }
+            },
+            "WANv6_IN" : {
+                "rule": {
+                    "1": {
+                            "action": "accept",
+                            "description": "Allow ICMPv6",
+                            "log": "enable",
+                            "protocol": "icmpv6"
+                    }
+                }
+            }
+        }
+    },
+    "interfaces": {
+        "ethernet": {
+            "eth0": {
+                "dhcp-options": {
+                    "default-route": "no-update",
+                    "default-route-distance": "1",
+                    "name-server": "no-update"
+                },
+                "description": "WAN",
+                "mtu": "1512",
+                "vif": {
+                    "4": {
+                        "address": [
+                            "dhcp"
+                        ],
+                        "description": "IPTV",
+                        "dhcp-options": {
+                            "client-option": [
+                                "send vendor-class-identifier &quot;IPTV_RG&quot;;",
+                                "request subnet-mask, routers, rfc3442-classless-static-routes;"
+                            ],
+                            "default-route": "no-update",
+                            "default-route-distance": "210",
+                            "name-server": "no-update"
+                        },
+                        "ip": {
+                            "source-validation": "loose"
+                        },
+                        "mtu": "1500"
+                    },
+                    "6": {
+                        "mtu": "1508",
+                        "firewall": {
+                            "in": {
+                                "ipv6-name": "WANv6_IN",
+                                "name": "WAN_IN"
+                            },
+                            "local": {
+                                "ipv6-name": "WANv6_LOCAL",
+                                "name": "WAN_LOCAL"
+                            },
+                            "out": {
+                                "ipv6-name": "WANv6_OUT",
+                                "name": "WAN_OUT"
+                            }
+                        },
+                        "pppoe": {
+                            "2": {
+                                "default-route": "auto",
+                                "firewall": {
+                                    "in": {
+                                        "ipv6-name": "WANv6_IN",
+                                        "name": "WAN_IN"
+                                    },
+                                    "local": {
+                                        "ipv6-name": "WANv6_LOCAL",
+                                        "name": "WAN_LOCAL"
+                                    },
+                                    "out": {
+                                        "ipv6-name": "WANv6_OUT",
+                                        "name": "WAN_OUT"
+                                    }
+                                },
+                                "ipv6": {
+                                    "address": {
+                                        "autoconf": "''"
+                                    },
+                                    "dup-addr-detect-transmits": "1",
+                                    "enable": "''"
+                                },
+                                "mtu": "1500",
+                                "name-server": "auto",
+                                "password": "kpn",
+                                "user-id": "kpn"
+                            }
+                        }
+                    }
+                }
+            },
+            "eth1": {
+                "description": "LAN",
+                "ipv6": {
+                    "address": {
+                        "autoconf": "''"
+                    },
+                    "dup-addr-detect-transmits": "1",
+                    "router-advert": {
+                        "cur-hop-limit": "64",
+                        "link-mtu": "0",
+                        "managed-flag": "true",
+                        "max-interval": "600",
+                        "name-server": [
+                        	"2606:4700:4700::1111",
+                        	"2606:4700:4700::1001"
+                        ],
+                        "other-config-flag": "false",
+                        "prefix": {
+                            "::/64": {
+                                "autonomous-flag": "true",
+                                "on-link-flag": "true",
+                                "valid-lifetime": "2592000"
+                            }
+                        },
+                        "radvd-options": "RDNSS 2606:4700:4700::1111 2606:4700:4700::1001 {};",
+                        "reachable-time": "0",
+                        "retrans-timer": "0",
+                        "send-advert": "true"
+                    }
+                }
+            }
+        }
+    },
+    "protocols": {
+        "igmp-proxy": {
+            "interface": {
+                "eth0.4": {
+                    "alt-subnet": [
+                        "0.0.0.0/0"
+                    ],
+                    "role": "upstream",
+                    "threshold": "1"
+                },
+                "eth1": {
+                    "alt-subnet": [
+                        "0.0.0.0/0"
+                    ],
+                    "role": "downstream",
+                    "threshold": "1"
+                }
+            }
+        },
+        "static": {
+            "interface-route6": {
+                "::/0": {
+                    "next-hop-interface": {
+                        "pppoe2": "''"
+                    }
+                }
+            }
+        }
+    },
+    "port-forward": {
+        "wan-interface": "pppoe2"
+    },
+    "service": {
+        "dns": {
+            "forwarding": {
+                "except-interface": [
+                    "pppoe2"
+                ]
+            }
+        },
+        "nat": {
+            "rule": {
+                "5000": {
+                    "description": "MASQ corporate_network to IPTV network",
+                    "destination": {
+                        "address": "213.75.112.0/21"
+                    },
+                    "log": "disable",
+                    "outbound-interface": "eth0.4",
+                    "protocol": "all",
+                    "type": "masquerade"
+                },
+                "6001": {
+                    "outbound-interface": "pppoe2"
+                },
+                "6002": {
+                    "outbound-interface": "pppoe2"
+                },
+                "6003": {
+                    "outbound-interface": "pppoe2"
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
I needed to remove the upnp2 service as I encountered a boot loop when it was in the config:

> Error: must define at least one listen-on interface