### PR TITLE
Improved README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,31 +5,39 @@ Klik [hier](https://coolhva.github.io/usg-kpn-ftth/posts/unifi-security-gateway-
 
 Please **[download a zip file](https://github.com/coolhva/usg-kpn-ftth/archive/master.zip)** with all the files and do not copy and paste the contents because of the UNIX file structure!
 
-1. Place **config.gateway.json** at the unifi controller (*sites/default*) via SCP
+## Unifi Controller
+
+1. Place **config.gateway.json** in the unifi controller (*<unifi_base>/data/sites/site_ID*) via SCP
+
+   You can check step 3 of [this guide](https://help.ubnt.com/hc/en-us/articles/215458888-UniFi-USG-Advanced-Configuration#2) on how you can find the *unifi_base* and the *site_ID*.
 
    The config.gateway.json contains the main configuration with the different interfaces which are needed for internet (vlan 6) and IPTV (vlan 4). IPv4 is configured via PPPoE with the kpn/kpn username and password. KPN uses a TAG which is configured in the DSLAM to identify your connection and to give you your "permanent" public IPv4 address.
 
-2. ~~Place **routes** in */etc/dhcp3/dhclient-exit-hooks.d/* via SCP~~
-3. ~~Execute `sudo chmod +x /etc/dhcp3/dhclient-exit-hooks.d/routes` on the USG~~
+## UGS
+
+1. ~~Place **routes** in */etc/dhcp3/dhclient-exit-hooks.d/* via SCP~~
+2. ~~Execute `sudo chmod +x /etc/dhcp3/dhclient-exit-hooks.d/routes` on the USG~~
 
    Step 2 and 3 are optional and can be skipped because the file is put in place by the **setroutes.sh** file, which is configured in step 6.
 
    KPN sends static routes via DHCP which the USG does not install by default. This script will install the DHCP routes when a DHCP lease is received. The chmod +x command allows the script to be executed. ([source](https://community.ubnt.com/t5/EdgeRouter/DHCP-CLIENT-OPTION-121-not-updates-routes-table/m-p/2506090/highlight/true#M223160))
 
-4. Place **dhcp6.sh** in */config/scripts/post-config.d/* via SCP
-5. Execute `chmod +x /config/scripts/post-config.d/dhcp6.sh` on the USG
+3. Place **dhcp6.sh** in */config/scripts/post-config.d/* via SCP
+4. Execute `chmod +x /config/scripts/post-config.d/dhcp6.sh` on the USG
 
    IPv6 works natively in the USG, the problem with KPN is that the json nesting will go to deep (interface, vlan and pppoe) and the USG will hit a bug ([source](https://community.ubnt.com/t5/UniFi-Routing-Switching/Configuration-commit-errors-IPv6-PPPoE-invalid-prefix-ID-value/td-p/2461935)) when it tries to parse the json. To overcome this, after 2 minutes the USG will execute this script which will configure IPv6 on the PPPoE interface and will remove the task from the taskscheduler.
 
-6. Place **setroutes.sh** in */config/scripts/post-config.d/* via SCP
-7. Execute `chmod +x /config/scripts/post-config.d/setroutes.sh` on the USG
+5. Place **setroutes.sh** in */config/scripts/post-config.d/* via SCP
+6. Execute `chmod +x /config/scripts/post-config.d/setroutes.sh` on the USG
 
    After each firmware upgrade the routes file, used by the dhcp client at the exit hook (for the IPTV routes), is removed. To overcome this, after 2 minutes the USG will execute this script which will create the routes file, renews the DHCP lease, restart the IGMP Proxy and remove the task from the taskscheduler.
 
-9. The lan network (and portfowarding if needed) needs to be configured in the Unifi controller
-9. Go to the USG in devices in the controller and force provisioning
+7. The lan network (and portforwarding if needed) needs to be configured in the Unifi controller
+8. Go to the USG in devices in the controller and force provisioning
 
 After provisioning please reboot the USG. After two minutes IPv6 will be enabled. This can be checked by executing `show interfaces` on the USG.
+
+If your USG is stuck provisioning, power cycle the USG, the switch that's connection to the USG and you Unifi Controller.
 
 The PPPOE interface has no "public" IPv6 address because it uses the link local IPv6 address to route traffic to KPN. To see the remote address execute the following command ([source](https://community.ubnt.com/t5/EdgeRouter/EdgeRouter-X-PPPoE-IPv6/td-p/1893221)):
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Please **[download a zip file](https://github.com/coolhva/usg-kpn-ftth/archive/m
 1. ~~Place **routes** in */etc/dhcp3/dhclient-exit-hooks.d/* via SCP~~
 2. ~~Execute `sudo chmod +x /etc/dhcp3/dhclient-exit-hooks.d/routes` on the USG~~
 
-   Step 2 and 3 are optional and can be skipped because the file is put in place by the **setroutes.sh** file, which is configured in step 6.
+   Step 1 and 2 are optional and can be skipped because the file is put in place by the **setroutes.sh** file, which is configured in step 5.
 
    KPN sends static routes via DHCP which the USG does not install by default. This script will install the DHCP routes when a DHCP lease is received. The chmod +x command allows the script to be executed. ([source](https://community.ubnt.com/t5/EdgeRouter/DHCP-CLIENT-OPTION-121-not-updates-routes-table/m-p/2506090/highlight/true#M223160))
 


### PR DESCRIPTION
I've improved the documentation by:

- Separating the actions performed on the Unifi Controller and the USG
- Including a link to find the path for the `config.gateway.json`
- Adding a possible solution for an USG that's stuck provisioning

I was able to configure everything successful with:

**Unifi Controller**: UniFi Cloud Key G2+ with `v1.1.6`
**Unifi Network**: `5.12.35-12979-1` with build `atag_5.12.35_12979`
**USG**: UniFi Security Gateway 3P with `4.4.44.5213844`